### PR TITLE
修复签名失败问题

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -67,6 +67,7 @@ func getSignature(request *tea.Request, accessKeySecret string) string {
 		if value != nil {
 			tmp := url.QueryEscape(tea.StringValue(value))
 			tmp = strings.ReplaceAll(tmp, "'", "%27")
+			tmp = strings.ReplaceAll(tmp, "+", "%20")
 			if strings.HasSuffix(resource, "?") {
 				resource = resource + key + "=" + tmp
 			} else {


### PR DESCRIPTION
https://help.aliyun.com/document_detail/54237.html?spm=a2c4g.11174283.6.669.28065a1949Z7Kf

对于 query=default:'测试' AND tag:'1'
会把空格转换成加号(+)导致签名错误