### PR TITLE
get the request query in order when getting the signature

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -63,7 +63,13 @@ func getSignature(request *tea.Request, accessKeySecret string) string {
 	if !strings.Contains(resource, "?") && len(request.Query) > 0 {
 		resource += "?"
 	}
-	for key, value := range request.Query {
+	queryKeys := make([]string, len(request.Query))
+	for k,_ := range request.Query {
+		queryKeys = append(queryKeys, k)
+	}
+	sort.Strings(queryKeys)
+	for _, key := range queryKeys {
+		value := request.Query[key]
 		if value != nil {
 			tmp := url.QueryEscape(tea.StringValue(value))
 			tmp = strings.ReplaceAll(tmp, "'", "%27")


### PR DESCRIPTION
因为 golang 的 map 是无序的，所以这里直接获取时，会导致同样的参数得到的 resource 变量有可能不一样，致使得到的签名不一样。

我在使用"下拉提示"功能时用到了该方法，同样的参数，一会是成功的，一会报错：
{"code":4003,"message":"Signature fail","params":{}}],"status":"FAIL","request_id":"1618925527323223637891658"}

追踪调试代码后，定位到这里